### PR TITLE
Initial implementation of target-PMID identification tooling

### DIFF
--- a/target-pmid-identification/Dockerfile
+++ b/target-pmid-identification/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.6
+
+RUN mkdir /work /output
+COPY main.sh extract-column.py /work/
+RUN chmod 755 /work/main.sh
+WORKDIR /work
+
+CMD /work/main.sh

--- a/target-pmid-identification/README.md
+++ b/target-pmid-identification/README.md
@@ -1,0 +1,17 @@
+## Identifying PMIDs in PMC but not in PMC-OA
+
+The scripts in this directory produce a list of PMIDs for documents that are present in PubMed Central (PMC), but are not available for text mining in either the PMC Open Access subset, or the NLM Author Manuscript collection.
+
+### Requirements
+* Docker
+
+### How to run
+```bash
+> docker build -t milestone10 .
+> docker run --rm -v [OUTPUT_PATH]:/output milestone10
+```
+where _[OUTPUT\_PATH]_ is an __absolute path__ to a directory on the host machine where the generated list of PMIDs will be stored. Two files are generated.
+* `pmids-not-available-as-full-text.txt`
+    * a list of PMIDs (one per line) for articles that are in PMC but are not available as full text for text-mining purposes
+* `pmids-with-available-full-text.txt`
+    * a list of PMIDs (one per line) for articles that are in PMC and are availablae as full text for text-mining purposes

--- a/target-pmid-identification/extract-column.py
+++ b/target-pmid-identification/extract-column.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import csv
+import sys, getopt
+import gzip
+
+# extracts a specified column from a specified CSV file
+def main(argv):
+   inputfile = ''
+   column=-1
+   try:
+      opts, args = getopt.getopt(argv,"hi:c:",["ifile=","column="])
+   except getopt.GetoptError:
+      print('extract-column.py -i <inputfile> -c <column>')
+      sys.exit(2)
+   for opt, arg in opts:
+      if opt == '-h':
+         print('extract-column.py -i <inputfile> -c <column>')
+         sys.exit()
+      elif opt in ("-i", "--ifile"):
+         inputfile = arg
+      elif opt in ("-c", "--column"):
+         column = int(arg)
+   
+   if inputfile.endswith(".gz"):
+      f = gzip.open(inputfile,'rt')
+   else:
+      f = open(inputfile, 'r')
+
+   reader = csv.reader(f, quotechar='"')
+   for row in reader:
+      print(row[column]) # row[-1] gives the last column
+
+   f.close()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/target-pmid-identification/main.sh
+++ b/target-pmid-identification/main.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+############################################
+#### Download relevant PMID index files ####
+############################################
+
+echo "Downloading the index file of PMC OA documents..."
+wget https://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_file_list.csv
+echo "Downloading the index file of the NIH Author Manuscript Collection..."
+wget https://ftp.ncbi.nlm.nih.gov/pub/pmc/manuscript/filelist.txt
+echo "Downloading the index file for all PMC documents..."
+wget https://ftp.ncbi.nlm.nih.gov/pub/pmc/PMC-ids.csv.gz
+
+
+# NOTE: it would be good to include the Historical OCR collection as well, however there is no index file
+# for that collection. See: https://ftp.ncbi.nlm.nih.gov/pub/pmc/historical_ocr/
+
+# NOTE: it would also be helpful if we could exclude documents where preprints exist
+
+
+########################################
+#### Extract PMIDs from index files ####
+########################################
+
+echo "Extracting all PMIDs cataloged in PMC..."
+python extract-column.py -i PMC-ids.csv.gz -c 9 | grep -v PMID | sort | uniq > all-pmids-in-pmc.txt
+echo "Extracting all PMIDs that are part of the NIH Author Manuscript Collection..."
+cat filelist.txt | tr -s " " | cut -f 3 -d " " | grep -v PMID > author-manuscript-pmids.txt
+echo "Extract all PMIDS that are part of the PMC OA Subset..."
+python extract-column.py -i oa_file_list.csv -c 4 | grep -v PMID > pmc-oa-pmids.txt
+
+echo "Combining PMIDs for articles where full text is available for text mining into a single list..."
+cat pmc-oa-pmids.txt author-manuscript-pmids.txt | sort | uniq > /output/pmids-with-available-full-text.txt
+AVAILABLE_COUNT=$(wc -l /output/pmids-with-available-full-text.txt)
+echo "PMIDs available as full text for text-mining purposes: $AVAILABLE_COUNT"
+
+
+#####################################################################
+#### Find PMIDs in PMC that are not in the full text collections ####
+#####################################################################
+
+echo "Computing set difference (all - pmids-with-available-full-text)..."
+comm -23 <(sort all-pmids-in-pmc.txt) <(sort /output/pmids-with-available-full-text.txt) | tr -d ' ' > /output/pmids-not-available-as-full-text.txt
+NOT_AVAILABLE_COUNT=$(wc -l /output/pmids-not-available-as-full-text.txt)
+echo "PMIDS NOT available as full text for text-mining purposes: $NOT_AVAILABLE_COUNT"


### PR DESCRIPTION
Scripts and accompanying Dockerfile capable of identifying PMIDs that are in PubMed Central, but are not available as full text for text-mining purposes. Instructions for running are in the README.md file.