### PR TITLE
Add csv generation

### DIFF
--- a/mining-orcid-email/src/author/author.service.ts
+++ b/mining-orcid-email/src/author/author.service.ts
@@ -2,6 +2,7 @@ import { Injectable, HttpService, Logger } from '@nestjs/common';
 import { OrcidService } from '../orcid/orcid.service';
 import { AuthorDto } from './dto/author-input.dto';
 import { AuthorResponseInterface } from './dto/author-response.interface';
+import { toDisk } from 'objects-to-csv';
 
 @Injectable()
 export class AuthorService {
@@ -11,28 +12,65 @@ export class AuthorService {
   ) {}
   logger = new Logger(AuthorService.name);
 
+  async sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  async writeToCsv(entries) {
+    const ObjectsToCsv = require('objects-to-csv');
+    const result = [];
+    const map = new Map();
+    for (const item of entries) {
+        console.log(item)
+        if(!map.has(item.pubMedId)){
+            map.set(item.pubMedId, true);    // set any value to Map
+            result.push({
+                pubMedId: item.pubMedId,
+                orcId: item.orcId,
+                name: item.name,
+                email: item.email,
+            });
+        }
+    }
+    //console.log(result)
+    const csv = new ObjectsToCsv(result);
+    await csv.toDisk('./list.csv', { append: true });
+
+  }
+
   async getAuthors(data: AuthorDto): Promise<AuthorResponseInterface[]> {
     // talk to orcid here.
     // orcid client -> getAuthorInfo()
     // output -> processsed to send response to the API call.
     const pubMedIds = data.pubMedIds
+    const entries = [];
     if (!pubMedIds) {
       return [];
     }
     const authorResponses = []
 	  for (let i = 0; i < pubMedIds.length; i++) {
-      const orcId = await this.orcidService.getOrcId(pubMedIds[i]);
+      const pubMedId = pubMedIds[i];
+      const orcId = await this.orcidService.getOrcId(pubMedId);
+      if (orcId) {
+        console.log(orcId)
+      }
       //console.log(`pubmed id: ${pubMedIds[i]}, orcid: ${orcId}`)
       const { name, email } = await this.orcidService.getOrcidEmail(orcId);
-      console.log(name, email)
+      const authorEntry = { name, email, orcId };
+      if (name || email) {
+        const csvEntry = { pubMedId, name, email, orcId };
+        entries.push(csvEntry);
+      }
       const entry = {
-        authors: [{name, email, orcId}],
+        authors: [authorEntry],
         pubMedId: pubMedIds[i],
         pmcId: 0,
         title: '',
       }
       authorResponses.push(entry)
+      this.sleep(100);
     }
+    await this.writeToCsv(entries);
     return authorResponses;
   }
 }

--- a/mining-orcid-email/src/orcid/__tests__/orcid.client.spec.ts
+++ b/mining-orcid-email/src/orcid/__tests__/orcid.client.spec.ts
@@ -103,7 +103,7 @@ describe('OrcidClient', () => {
       });
     });
 
-    describe('when Front rejects the request', () => {
+    describe('when orcid rejects the request', () => {
       it('should log the error and throw HttpException', async () => {
         const err: AxiosError<any> = {
           name: 'Error',
@@ -145,4 +145,47 @@ describe('OrcidClient', () => {
       });
     });
   });
+    describe('getOrcId', () => {
+      it('should retry five times before failing', async () => {
+        const err: AxiosError<any> = {
+          name: 'Error',
+          message: '400 Bad Request',
+          response: {
+            status: 400,
+            data: { errors: [{ message: 'Orcid Test Error' }] },
+            statusText: 'Bad Request',
+            config: undefined,
+            headers: undefined,
+          },
+          config: undefined,
+          isAxiosError: false,
+          toJSON: jest.fn(),
+        };
+        const requestSpy = jest.spyOn(httpService, 'request').mockImplementation(() => of(Promise.reject(err) as any));
+        await client.getOrcId(1234);
+        expect(requestSpy).toBeCalledTimes(5);
+      });
+      it('should retry once before passing', async () => {
+        const err: AxiosError<any> = {
+          name: 'Error',
+          message: '400 Bad Request',
+          response: {
+            status: 400,
+            data: { errors: [{ message: 'Orcid Test Error' }] },
+            statusText: 'Bad Request',
+            config: undefined,
+            headers: undefined,
+          },
+          config: undefined,
+          isAxiosError: false,
+          toJSON: jest.fn(),
+        };
+        const requestSpy = jest.spyOn(httpService, 'request').mockImplementationOnce(() => of(Promise.reject(err) as any));
+        jest
+          .spyOn(httpService, 'request')
+          .mockImplementation(() => of({ data: { message: 'Orcid Test Response' } } as any));
+        await client.getOrcId(1234);
+        expect(requestSpy).toBeCalledTimes(2);
+      });
+    });
 });

--- a/mining-orcid-email/src/orcid/__tests__/orcid.service.spec.ts
+++ b/mining-orcid-email/src/orcid/__tests__/orcid.service.spec.ts
@@ -47,7 +47,7 @@ describe('OrcidService', () => {
     });
     describe('#getEmailFromOrcId', () => {
         beforeEach(() => {
-            jest.spyOn(client, 'getOrcidEmail').mockResolvedValue(orcidEmailResponseNoEmail);
+            jest.spyOn(client, 'getOrcIdEmail').mockResolvedValue(orcidEmailResponseNoEmail);
         });
 
         it('should return empty object', async () => {

--- a/mining-orcid-email/src/orcid/dto/orcid.publication.interface.ts
+++ b/mining-orcid-email/src/orcid/dto/orcid.publication.interface.ts
@@ -1,0 +1,11 @@
+
+export interface OrcidPublicationResponseInterface {
+    /** Name of the author */
+    title: string;
+  
+    /** Email of the author. */
+    date: string;
+    issn: string;
+    doi: string;
+    type: string;
+}

--- a/mining-orcid-email/src/orcid/orcid.client.ts
+++ b/mining-orcid-email/src/orcid/orcid.client.ts
@@ -1,6 +1,8 @@
 import { Injectable, HttpService, Logger, HttpStatus, HttpException } from '@nestjs/common';
 import { ConfigService} from '@nestjs/config';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { Method } from 'axios';
+import { SSL_OP_EPHEMERAL_RSA } from 'constants';
 
 @Injectable()
 export class OrcidClient {
@@ -55,6 +57,10 @@ export class OrcidClient {
       throw new HttpException(errorData, status);
     }
   }
+
+  async sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
   
   public async getOrcIdEmail(orcId: string) {
     //orcId = '0000-0003-1455-3370';
@@ -62,8 +68,18 @@ export class OrcidClient {
       const url = `https://pub.orcid.org/v2.1/${orcId}/email`;
       const token = this.configService.get('ORCID_AUTH_KEY');
       //console.log(`token: ${process.env.ORCID_AUTH_KEY}`);
-      const response = await this.makeRequest('GET', url, token);
-      return response;
+      let numRetries = 0;
+      while (numRetries < 5) {
+        try {
+          const response = await this.makeRequest('GET', url, token);
+          return response;
+        } catch (error) {
+          console.log(error)
+          console.log(`retry: ${numRetries}`)
+          ++numRetries;
+          this.sleep(100);
+        }
+      }
     }
     return undefined;
   }
@@ -71,7 +87,20 @@ export class OrcidClient {
   public async getOrcId(pubMedId: number) {
     const url = `https://pub.orcid.org/v3.0/search/?q=pmid-self:${pubMedId}`;
     const token = this.configService.get('ORCID_AUTH_KEY');
-    const response = await this.makeRequest('GET', url, token);
-    return response;
+    let responseReceived = false;
+    let numRetries = 0;
+    while (numRetries < 5) {
+      try {
+        const response = await this.makeRequest('GET', url, token);
+        if (numRetries > 1) {
+          console.log(`pubmed id: ${pubMedId} done.`)
+        }
+        return response;
+      } catch (error) {
+        console.log(`retrying ${pubMedId}: ${numRetries}`)
+        ++numRetries;
+        this.sleep(100);
+      }
+    }
   }
 }

--- a/mining-orcid-email/src/orcid/orcid.client.ts
+++ b/mining-orcid-email/src/orcid/orcid.client.ts
@@ -1,8 +1,6 @@
 import { Injectable, HttpService, Logger, HttpStatus, HttpException } from '@nestjs/common';
 import { ConfigService} from '@nestjs/config';
-import { APP_INTERCEPTOR } from '@nestjs/core';
 import { Method } from 'axios';
-import { SSL_OP_EPHEMERAL_RSA } from 'constants';
 
 @Injectable()
 export class OrcidClient {

--- a/mining-orcid-email/src/orcid/orcid.service.ts
+++ b/mining-orcid-email/src/orcid/orcid.service.ts
@@ -9,34 +9,51 @@ export class OrcidService {
   constructor(private readonly orcidClient: OrcidClient) {}
 
   retrieveEmail(orcidEmailResponse: string): OrcidEmailResponseInterface {
-    console.log(orcidEmailResponse)
+    let name, email;
     if(validate(orcidEmailResponse) === true) { //optional (it'll return an object in case it's not valid)
       const orcidJson = parse(orcidEmailResponse, {});
+      //console.log(JSON.stringify(orcidJson, null, 2))
       if (
-          orcidJson['email:emails'] && 
-          orcidJson['email:emails']['email:email'] && 
+          orcidJson['email:emails'] &&
+          orcidJson['email:emails']['email:email'] &&
           orcidJson['email:emails']['email:email']['email:email']
       ) {
-        const email = orcidJson['email:emails']['email:email']['email:email'];
-        let name = '';
+        email = orcidJson['email:emails']['email:email']['email:email'];
         if (
-            orcidJson['email:emails'] && 
-            orcidJson['email:emails']['email:email'] && 
+            orcidJson['email:emails'] &&
+            orcidJson['email:emails']['email:email'] &&
             orcidJson['email:emails']['email:email']['common:source'] &&
             orcidJson['email:emails']['email:email']['common:source']['common:source-name']
         ) {
           name = orcidJson['email:emails']['email:email']['common:source']['common:source-name'];
         }
-        return {
-          email, name
+      } else if (
+          orcidJson['email:emails'] &&
+          orcidJson['email:emails']['email:email']
+        ) {
+        const entries = orcidJson['email:emails']['email:email']
+        for (let index = 0; index < entries.length; index++) {
+          const entry = entries[index];
+          console.log(entry)
+          if (entry['email:email']) {
+            email = entry['email:email']
+          }
+          if (
+            entry['common:source'] &&
+            entry['common:source']['common:source-name']
+          ) {
+            name = entry['common:source']['common:source-name']
+          }
+          console.log(`Email: ${email}, name: ${name}`)
+          if (email) {
+            break
+          }
         }
-      } else {
-        console.log(`unable to find email from orcid response: ${JSON.stringify(orcidJson, null, 2)}`);
       }
     }
     return {
-      name: '',
-      email: '',
+      name,
+      email,
     }
   }
 
@@ -44,7 +61,6 @@ export class OrcidService {
     const response = await this.orcidClient.getOrcIdEmail(orcid);
     if (response) {
       const emailObj = this.retrieveEmail(response);
-      console.log(emailObj);
       return emailObj;
     }
     return {
@@ -59,8 +75,8 @@ export class OrcidService {
       if (
         orcidJson['search:search'] &&
         orcidJson['search:search']['search:result'] &&
-        orcidJson['search:search']['search:result']['common:orcid-identified'] &&
-        orcidJson['search:search']['search:result']['common:orcid-identified']['common:path']
+        orcidJson['search:search']['search:result']['common:orcid-identifier'] &&
+        orcidJson['search:search']['search:result']['common:orcid-identifier']['common:path']
       ) {
         const orcid = orcidJson['search:search']['search:result']['common:orcid-identifier']['common:path'];
         return orcid

--- a/target-pmid-identification/mine-emails.py
+++ b/target-pmid-identification/mine-emails.py
@@ -7,8 +7,8 @@ def batch(iterable, n=1):
     for ndx in range(0, l, n):
         yield iterable[ndx:min(ndx + n, l)]
 
-filename = './output/pmids-not-available-as-full-text.txt'
-# filename = './output/pmids-sample.txt'
+#filename = './output/pmids-not-available-as-full-text.txt'
+filename = './output/pmids-sample.txt'
 with open(filename) as f:
     lines = f.readlines()
 
@@ -18,11 +18,14 @@ headers = {
   'Content-Type': 'application/json'
 }
 
+batch_size = 3000
 pubmed_ids = [int(numeric_string) for numeric_string in lines]
+#remaining_pubmed_ids = pubmed_ids[(167 + 211 + 108 + 550)*3000:]
 
 authors_with_orcid = 0
+authors_with_email = 0
 batch_num = 0
-for pubmed_ids_batch in batch(pubmed_ids, 5000):
+for pubmed_ids_batch in batch(pubmed_ids, batch_size):
     print(f'Starting batch: {batch_num}')
     body = {
         'pubMedIds': pubmed_ids_batch
@@ -31,11 +34,18 @@ for pubmed_ids_batch in batch(pubmed_ids, 5000):
     print(f'Got response for batch: {batch_num}')
     if response.ok:
         entries = json.loads(response.text)
-        for entry in entries:
-           for author in entry['authors']:
-            if author['orcId']:
-                authors_with_orcid += 1
-    print(f'Authors with orcid: {authors_with_orcid}')
+        for entry in entries: 
+            for author in entry['authors']: 
+                author_orcid = author.get('orcId', '')
+                author_email = author.get('email', '')
+                if author_orcid:
+                    authors_with_orcid += 1 
+                if author_orcid and author_email:
+                    pubmed_id = entry['pubMedId']
+                    orcid = author['orcId']
+                    print(f'PubMed Id: {pubmed_id}, author: {author}')
+                    authors_with_email += 1
+    print(f'Authors with orcid: {authors_with_orcid}, Authors with email: {authors_with_email}')
     batch_num += 1
 
     


### PR DESCRIPTION
- Added logic to retry if ORCID client is unable to get the record for a specific PubMedID
- Fixed the error with getting identifiers from the email record when there were more than one records associated with a user. Take the first record.
- Added CSV generation so the name, email, pubmedid, ORCID is written out in CSV format. 
